### PR TITLE
タスク関連のCRUD処理＆APIエントリ追加

### DIFF
--- a/cmd/todolist/main.go
+++ b/cmd/todolist/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	firebase "firebase.google.com/go"
+	"github.com/gin-gonic/gin"
 	"github.com/kzuabe/todolist-go-api/internal/controller"
 	"github.com/kzuabe/todolist-go-api/internal/repository"
 	"github.com/kzuabe/todolist-go-api/internal/router"
@@ -13,13 +14,23 @@ import (
 	"github.com/kzuabe/todolist-go-api/pkg/middleware"
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
 )
 
+var gormLogMode = logger.Info
+
 func main() {
+	// 環境ごとのセットアップ
+	if os.Getenv("API_ENV") == "production" {
+		gin.SetMode(gin.ReleaseMode)
+		gormLogMode = logger.Error
+	}
 
 	// DB セットアップ
 	dsn := os.Getenv("DSN") + "?charset=utf8mb4&parseTime=True&loc=Local"
-	db, err := gorm.Open(mysql.Open(dsn), &gorm.Config{})
+	db, err := gorm.Open(mysql.Open(dsn), &gorm.Config{
+		Logger: logger.Default.LogMode(gormLogMode),
+	})
 	if err != nil {
 		panic("failed to connect database")
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.17
 require (
 	firebase.google.com/go v3.13.0+incompatible
 	github.com/gin-gonic/gin v1.7.7
+	github.com/google/uuid v1.3.0
 	gorm.io/driver/mysql v1.2.1
 	gorm.io/gorm v1.22.4
 )

--- a/go.sum
+++ b/go.sum
@@ -175,8 +175,9 @@ github.com/google/pprof v0.0.0-20210601050228-01bbb1931b22/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210609004039-a478d1d731e9/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
-github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gax-go/v2 v2.1.0/go.mod h1:Q3nei7sK6ybPYH7twZdmQpAd1MKb7pfu6SK+H1/DsU0=

--- a/internal/controller/task.go
+++ b/internal/controller/task.go
@@ -17,6 +17,7 @@ type TaskController struct {
 type TaskControllerInterface interface {
 	Get(c *gin.Context)
 	Post(c *gin.Context)
+	Put(c *gin.Context)
 }
 
 func (controller *TaskController) Get(c *gin.Context) {
@@ -46,4 +47,19 @@ func (controller *TaskController) Post(c *gin.Context) {
 	created, _ := controller.UseCase.Create(task)
 
 	c.IndentedJSON(http.StatusCreated, created)
+}
+
+func (controller *TaskController) Put(c *gin.Context) {
+	token, _ := c.MustGet(middleware.CONTEXT_TOKEN_KEY).(*auth.Token)
+
+	task := entity.Task{}
+	if err := c.ShouldBindJSON(&task); err != nil {
+		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": err.Error()})
+		return
+	}
+	task.ID = c.Param("id")
+	task.UserID = token.UID
+
+	updated, _ := controller.UseCase.Update(task)
+	c.IndentedJSON(http.StatusCreated, updated)
 }

--- a/internal/controller/task.go
+++ b/internal/controller/task.go
@@ -16,6 +16,7 @@ type TaskController struct {
 
 type TaskControllerInterface interface {
 	Get(c *gin.Context)
+	GetByID(c *gin.Context)
 	Post(c *gin.Context)
 	Put(c *gin.Context)
 	Delete(c *gin.Context)
@@ -33,6 +34,13 @@ func (controller *TaskController) Get(c *gin.Context) {
 
 	tasks, _ := controller.UseCase.Fetch(params)
 	c.IndentedJSON(http.StatusOK, tasks)
+}
+
+func (controller *TaskController) GetByID(c *gin.Context) {
+	token, _ := c.MustGet(middleware.CONTEXT_TOKEN_KEY).(*auth.Token)
+	id := c.Param("id")
+	task, _ := controller.UseCase.FetchByID(id, token.UID)
+	c.IndentedJSON(http.StatusOK, task)
 }
 
 func (controller *TaskController) Post(c *gin.Context) {

--- a/internal/controller/task.go
+++ b/internal/controller/task.go
@@ -3,7 +3,9 @@ package controller
 import (
 	"net/http"
 
+	"firebase.google.com/go/auth"
 	"github.com/gin-gonic/gin"
+	"github.com/kzuabe/todolist-go-api/internal/entity"
 	"github.com/kzuabe/todolist-go-api/internal/usecase"
 )
 
@@ -13,9 +15,25 @@ type TaskController struct {
 
 type TaskControllerInterface interface {
 	Get(c *gin.Context)
+	Post(c *gin.Context)
 }
 
 func (controller *TaskController) Get(c *gin.Context) {
 	tasks, _ := controller.UseCase.Fetch()
 	c.IndentedJSON(http.StatusOK, tasks)
+}
+
+func (controller *TaskController) Post(c *gin.Context) {
+	token, _ := c.MustGet("token").(*auth.Token)
+
+	task := entity.Task{}
+	if err := c.ShouldBindJSON(&task); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"message": err.Error()})
+		return
+	}
+	task.UserID = token.UID
+
+	created, _ := controller.UseCase.Create(task)
+
+	c.IndentedJSON(http.StatusCreated, created)
 }

--- a/internal/controller/task.go
+++ b/internal/controller/task.go
@@ -18,6 +18,7 @@ type TaskControllerInterface interface {
 	Get(c *gin.Context)
 	Post(c *gin.Context)
 	Put(c *gin.Context)
+	Delete(c *gin.Context)
 }
 
 func (controller *TaskController) Get(c *gin.Context) {
@@ -62,4 +63,14 @@ func (controller *TaskController) Put(c *gin.Context) {
 
 	updated, _ := controller.UseCase.Update(task)
 	c.IndentedJSON(http.StatusCreated, updated)
+}
+
+func (controller *TaskController) Delete(c *gin.Context) {
+	token, _ := c.MustGet(middleware.CONTEXT_TOKEN_KEY).(*auth.Token)
+
+	id := c.Param("id")
+	userID := token.UID
+
+	_ = controller.UseCase.Delete(id, userID)
+	c.Status(http.StatusNoContent)
 }

--- a/internal/entity/task.go
+++ b/internal/entity/task.go
@@ -1,9 +1,9 @@
 package entity
 
 type Task struct {
-	ID          uint
-	UserID      string
-	Title       string
-	Description string
-	Status      string // todo: 未着手, wip: 進行中, done: 完了
+	ID          string `json:"id"` // UUID
+	UserID      string `json:"user_id"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	Status      int    `json:"status"` // 0: 未着手, 1: 進行中, 2: 完了
 }

--- a/internal/entity/task.go
+++ b/internal/entity/task.go
@@ -2,8 +2,13 @@ package entity
 
 type Task struct {
 	ID          string `json:"id"` // UUID
-	UserID      string `json:"user_id"`
+	UserID      string `json:"-"`  // NOTE: 自明のためリクエスト・レスポンスボディに含めない
 	Title       string `json:"title"`
 	Description string `json:"description"`
 	Status      int    `json:"status"` // 0: 未着手, 1: 完了
+}
+
+type TaskFetchParam struct {
+	UserID string `form:"-"`
+	Status *int   `form:"status"`
 }

--- a/internal/entity/task.go
+++ b/internal/entity/task.go
@@ -5,5 +5,5 @@ type Task struct {
 	UserID      string `json:"user_id"`
 	Title       string `json:"title"`
 	Description string `json:"description"`
-	Status      int    `json:"status"` // 0: 未着手, 1: 進行中, 2: 完了
+	Status      int    `json:"status"` // 0: 未着手, 1: 完了
 }

--- a/internal/repository/task.go
+++ b/internal/repository/task.go
@@ -11,6 +11,7 @@ type TaskRepository struct {
 
 type TaskRepositoryInterface interface {
 	Fetch(entity.TaskFetchParam) ([]entity.Task, error)
+	FetchByID(string, string) (entity.Task, error)
 	Create(entity.Task) (entity.Task, error)
 	Update(entity.Task) (entity.Task, error)
 	Delete(string, string) error
@@ -39,6 +40,16 @@ func (repository *TaskRepository) Fetch(params entity.TaskFetchParam) ([]entity.
 		tasks[i] = toEntityTask(t)
 	}
 	return tasks, result.Error
+}
+
+func (repository *TaskRepository) FetchByID(id string, userID string) (entity.Task, error) {
+	t := Task{}
+
+	result := repository.DB.First(&t, "uuid = ?", id)
+	if t.UserID != userID { // TODO: エラーハンドリング
+		return entity.Task{}, nil
+	}
+	return toEntityTask(t), result.Error
 }
 
 func (repository *TaskRepository) Create(task entity.Task) (entity.Task, error) {

--- a/internal/repository/task.go
+++ b/internal/repository/task.go
@@ -12,6 +12,7 @@ type TaskRepository struct {
 type TaskRepositoryInterface interface {
 	Fetch(entity.TaskFetchParam) ([]entity.Task, error)
 	Create(entity.Task) (entity.Task, error)
+	Update(entity.Task) (entity.Task, error)
 }
 
 type Task struct {
@@ -44,6 +45,22 @@ func (repository *TaskRepository) Create(task entity.Task) (entity.Task, error) 
 	result := repository.DB.Create(&t)
 	created := toEntityTask(t)
 	return created, result.Error
+}
+
+func (repository *TaskRepository) Update(task entity.Task) (entity.Task, error) {
+	t := Task{}
+	_ = repository.DB.First(&t, "uuid = ?", task.ID) // TODO: エラーハンドリング
+	if t.UserID != task.UserID {
+		return entity.Task{}, nil
+	}
+
+	// 更新内容
+	t.Title = task.Title
+	t.Description = task.Description
+	t.Status = task.Status
+
+	result := repository.DB.Save(&t)
+	return toEntityTask(t), result.Error
 }
 
 func toDBTask(task entity.Task) Task {

--- a/internal/repository/task.go
+++ b/internal/repository/task.go
@@ -13,6 +13,7 @@ type TaskRepositoryInterface interface {
 	Fetch(entity.TaskFetchParam) ([]entity.Task, error)
 	Create(entity.Task) (entity.Task, error)
 	Update(entity.Task) (entity.Task, error)
+	Delete(string, string) error
 }
 
 type Task struct {
@@ -61,6 +62,11 @@ func (repository *TaskRepository) Update(task entity.Task) (entity.Task, error) 
 
 	result := repository.DB.Save(&t)
 	return toEntityTask(t), result.Error
+}
+
+func (repository *TaskRepository) Delete(id string, userID string) error {
+	result := repository.DB.Delete(&Task{}, "uuid = ? AND user_id = ?", id, userID)
+	return result.Error
 }
 
 func toDBTask(task entity.Task) Task {

--- a/internal/repository/task.go
+++ b/internal/repository/task.go
@@ -10,7 +10,7 @@ type TaskRepository struct {
 }
 
 type TaskRepositoryInterface interface {
-	Fetch() ([]entity.Task, error)
+	Fetch(entity.TaskFetchParam) ([]entity.Task, error)
 	Create(entity.Task) (entity.Task, error)
 }
 
@@ -23,8 +23,15 @@ type Task struct {
 	Status      int
 }
 
-func (repository *TaskRepository) Fetch() ([]entity.Task, error) {
-	return []entity.Task{}, nil
+func (repository *TaskRepository) Fetch(params entity.TaskFetchParam) ([]entity.Task, error) {
+	tx := repository.DB.Session(&gorm.Session{})
+	if status := params.Status; status != nil {
+		tx = tx.Where("status = ?", status)
+	}
+
+	tasks := []entity.Task{}
+	result := tx.Find(&tasks, "user_id = ?", params.UserID)
+	return tasks, result.Error
 }
 
 func (repository *TaskRepository) Create(task entity.Task) (entity.Task, error) {

--- a/internal/repository/task.go
+++ b/internal/repository/task.go
@@ -11,10 +11,12 @@ type TaskRepository struct {
 
 type TaskRepositoryInterface interface {
 	Fetch() ([]entity.Task, error)
+	Create(entity.Task) (entity.Task, error)
 }
 
 type Task struct {
 	gorm.Model
+	UUID        string
 	UserID      string
 	Title       string
 	Description string
@@ -23,4 +25,33 @@ type Task struct {
 
 func (repository *TaskRepository) Fetch() ([]entity.Task, error) {
 	return []entity.Task{}, nil
+}
+
+func (repository *TaskRepository) Create(task entity.Task) (entity.Task, error) {
+	t := toDBTask(task)
+	result := repository.DB.Create(&t)
+	created := toEntityTask(t)
+	return created, result.Error
+}
+
+func toDBTask(task entity.Task) Task {
+	t := Task{
+		UUID:        task.ID,
+		UserID:      task.UserID,
+		Title:       task.Title,
+		Description: task.Description,
+		Status:      task.Status,
+	}
+	return t
+}
+
+func toEntityTask(task Task) entity.Task {
+	t := entity.Task{
+		ID:          task.UUID,
+		UserID:      task.UserID,
+		Title:       task.Title,
+		Description: task.Description,
+		Status:      task.Status,
+	}
+	return t
 }

--- a/internal/repository/task.go
+++ b/internal/repository/task.go
@@ -29,8 +29,13 @@ func (repository *TaskRepository) Fetch(params entity.TaskFetchParam) ([]entity.
 		tx = tx.Where("status = ?", status)
 	}
 
-	tasks := []entity.Task{}
-	result := tx.Find(&tasks, "user_id = ?", params.UserID)
+	dbTasks := []Task{} // FIXME: RepositoryのTaskにする
+	result := tx.Find(&dbTasks, "user_id = ?", params.UserID)
+
+	tasks := make([]entity.Task, len(dbTasks))
+	for i, t := range dbTasks {
+		tasks[i] = toEntityTask(t)
+	}
 	return tasks, result.Error
 }
 

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -18,6 +18,7 @@ func NewRouter(h Handler) *gin.Engine {
 	v1 := router.Group("/v1")
 	{
 		v1.GET("/tasks", h.TaskController.Get)
+		v1.GET("tasks/:id", h.TaskController.GetByID)
 		v1.POST("/tasks", h.TaskController.Post)
 		v1.PUT("/tasks/:id", h.TaskController.Put)
 		v1.DELETE("/tasks/:id", h.TaskController.Delete)

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -19,6 +19,7 @@ func NewRouter(h Handler) *gin.Engine {
 	{
 		v1.GET("/tasks", h.TaskController.Get)
 		v1.POST("/tasks", h.TaskController.Post)
+		v1.PUT("/tasks/:id", h.TaskController.Put)
 	}
 
 	return router

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -20,6 +20,7 @@ func NewRouter(h Handler) *gin.Engine {
 		v1.GET("/tasks", h.TaskController.Get)
 		v1.POST("/tasks", h.TaskController.Post)
 		v1.PUT("/tasks/:id", h.TaskController.Put)
+		v1.DELETE("/tasks/:id", h.TaskController.Delete)
 	}
 
 	return router

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -18,6 +18,7 @@ func NewRouter(h Handler) *gin.Engine {
 	v1 := router.Group("/v1")
 	{
 		v1.GET("/tasks", h.TaskController.Get)
+		v1.POST("/tasks", h.TaskController.Post)
 	}
 
 	return router

--- a/internal/usecase/task.go
+++ b/internal/usecase/task.go
@@ -15,6 +15,7 @@ type TaskUseCase struct {
 type TaskUseCaseInterface interface {
 	Fetch(entity.TaskFetchParam) ([]entity.Task, error)
 	Create(entity.Task) (entity.Task, error)
+	Update(entity.Task) (entity.Task, error)
 }
 
 func (useCase *TaskUseCase) Fetch(params entity.TaskFetchParam) ([]entity.Task, error) {
@@ -26,4 +27,8 @@ func (useCase *TaskUseCase) Create(task entity.Task) (entity.Task, error) {
 	task.ID = uuid
 	task.Status = 0 // ステータスの初期値を未着手にする
 	return useCase.Repository.Create(task)
+}
+
+func (useCase *TaskUseCase) Update(task entity.Task) (entity.Task, error) {
+	return useCase.Repository.Update(task)
 }

--- a/internal/usecase/task.go
+++ b/internal/usecase/task.go
@@ -1,6 +1,9 @@
 package usecase
 
 import (
+	"strings"
+
+	"github.com/google/uuid"
 	"github.com/kzuabe/todolist-go-api/internal/entity"
 	"github.com/kzuabe/todolist-go-api/internal/repository"
 )
@@ -11,8 +14,16 @@ type TaskUseCase struct {
 
 type TaskUseCaseInterface interface {
 	Fetch() ([]entity.Task, error)
+	Create(entity.Task) (entity.Task, error)
 }
 
 func (useCase *TaskUseCase) Fetch() ([]entity.Task, error) {
 	return useCase.Repository.Fetch()
+}
+
+func (useCase *TaskUseCase) Create(task entity.Task) (entity.Task, error) {
+	uuid := strings.ReplaceAll(uuid.NewString(), "-", "") // UUIDの生成（ハイフン除去済み）
+	task.ID = uuid
+	task.Status = 0 // ステータスの初期値を未着手にする
+	return useCase.Repository.Create(task)
 }

--- a/internal/usecase/task.go
+++ b/internal/usecase/task.go
@@ -13,12 +13,12 @@ type TaskUseCase struct {
 }
 
 type TaskUseCaseInterface interface {
-	Fetch() ([]entity.Task, error)
+	Fetch(entity.TaskFetchParam) ([]entity.Task, error)
 	Create(entity.Task) (entity.Task, error)
 }
 
-func (useCase *TaskUseCase) Fetch() ([]entity.Task, error) {
-	return useCase.Repository.Fetch()
+func (useCase *TaskUseCase) Fetch(params entity.TaskFetchParam) ([]entity.Task, error) {
+	return useCase.Repository.Fetch(params)
 }
 
 func (useCase *TaskUseCase) Create(task entity.Task) (entity.Task, error) {

--- a/internal/usecase/task.go
+++ b/internal/usecase/task.go
@@ -16,6 +16,7 @@ type TaskUseCaseInterface interface {
 	Fetch(entity.TaskFetchParam) ([]entity.Task, error)
 	Create(entity.Task) (entity.Task, error)
 	Update(entity.Task) (entity.Task, error)
+	Delete(string, string) error
 }
 
 func (useCase *TaskUseCase) Fetch(params entity.TaskFetchParam) ([]entity.Task, error) {
@@ -30,4 +31,8 @@ func (useCase *TaskUseCase) Create(task entity.Task) (entity.Task, error) {
 
 func (useCase *TaskUseCase) Update(task entity.Task) (entity.Task, error) {
 	return useCase.Repository.Update(task)
+}
+
+func (useCase *TaskUseCase) Delete(id string, userID string) error {
+	return useCase.Repository.Delete(id, userID)
 }

--- a/internal/usecase/task.go
+++ b/internal/usecase/task.go
@@ -25,7 +25,6 @@ func (useCase *TaskUseCase) Fetch(params entity.TaskFetchParam) ([]entity.Task, 
 func (useCase *TaskUseCase) Create(task entity.Task) (entity.Task, error) {
 	uuid := strings.ReplaceAll(uuid.NewString(), "-", "") // UUIDの生成（ハイフン除去済み）
 	task.ID = uuid
-	task.Status = 0 // ステータスの初期値を未着手にする
 	return useCase.Repository.Create(task)
 }
 

--- a/internal/usecase/task.go
+++ b/internal/usecase/task.go
@@ -14,6 +14,7 @@ type TaskUseCase struct {
 
 type TaskUseCaseInterface interface {
 	Fetch(entity.TaskFetchParam) ([]entity.Task, error)
+	FetchByID(string, string) (entity.Task, error)
 	Create(entity.Task) (entity.Task, error)
 	Update(entity.Task) (entity.Task, error)
 	Delete(string, string) error
@@ -21,6 +22,10 @@ type TaskUseCaseInterface interface {
 
 func (useCase *TaskUseCase) Fetch(params entity.TaskFetchParam) ([]entity.Task, error) {
 	return useCase.Repository.Fetch(params)
+}
+
+func (useCae *TaskUseCase) FetchByID(id string, userID string) (entity.Task, error) {
+	return useCae.Repository.FetchByID(id, userID)
 }
 
 func (useCase *TaskUseCase) Create(task entity.Task) (entity.Task, error) {

--- a/pkg/middleware/firebase.go
+++ b/pkg/middleware/firebase.go
@@ -9,6 +9,8 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+const CONTEXT_TOKEN_KEY = "token"
+
 type FirebaseAuthMiddleware struct {
 	Client *auth.Client
 }
@@ -32,7 +34,7 @@ func (middleware *FirebaseAuthMiddleware) MiddlewareFunc() gin.HandlerFunc {
 			c.Abort()
 			return
 		}
-		c.Set("token", token)
+		c.Set(CONTEXT_TOKEN_KEY, token)
 		c.Next()
 	}
 }


### PR DESCRIPTION
# 概要
- タスクの取得・追加・更新・削除の処理を追加
  - `GET /v1/tasks` -> 取得（全件）
  - `GET /v1/tasks/:id` -> 取得（1件）
  - `POST /v1/tasks` -> 追加
  - `PUT /v1/tasks/:id` -> 更新
  - `DELETE /v1/tasks/:id` -> 削除