### PR TITLE
FirebaseAdmin初期化処理の修正

### DIFF
--- a/cmd/todolist/main.go
+++ b/cmd/todolist/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/base64"
 	"log"
 	"os"
 
@@ -13,7 +12,6 @@ import (
 	"github.com/kzuabe/todolist-go-api/internal/router"
 	"github.com/kzuabe/todolist-go-api/internal/usecase"
 	"github.com/kzuabe/todolist-go-api/pkg/middleware"
-	"google.golang.org/api/option"
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
@@ -45,12 +43,7 @@ func main() {
 	db.AutoMigrate(&repository.Task{})
 
 	// Firebase Admin セットアップ
-	data, err := base64.StdEncoding.DecodeString(os.Getenv("GOOGLE_APPLICATION_CREDENTIALS_JSON"))
-	if err != nil {
-		log.Fatalf("error get credentials json: %v\n", err)
-	}
-	opt := option.WithCredentialsJSON(data)
-	firebaseApp, err := firebase.NewApp(context.Background(), nil, opt)
+	firebaseApp, err := firebase.NewApp(context.Background(), nil)
 	if err != nil {
 		log.Fatalf("error initializing app: %v\n", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/swaggo/gin-swagger v1.3.3
 	github.com/swaggo/swag v1.7.8
-	google.golang.org/api v0.63.0
 	gorm.io/driver/mysql v1.2.1
 	gorm.io/gorm v1.22.4
 )
@@ -57,6 +56,7 @@ require (
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/tools v0.1.8 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	google.golang.org/api v0.63.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20211208223120-3a66f561d7aa // indirect
 	google.golang.org/grpc v1.40.1 // indirect


### PR DESCRIPTION
# 概要
- dockerのイメージ用にbase64エンコードしたjson文字列を直接環境変数で渡してFirebaseAdminを初期化していたが、処理が煩雑なのでやめた
- 手順は公式のセットアップ手順に従う
  - https://firebase.google.com/docs/admin/setup?hl=ja
- dockerはvolumeからjsonファイルを取得する